### PR TITLE
Updated CRT dependency to v0.3.10 for OSX support

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
-      <version>0.3.8</version>
+      <version>0.3.10</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
